### PR TITLE
Fix todo markers

### DIFF
--- a/ui/library/src/components/PageNumberControl.tsx
+++ b/ui/library/src/components/PageNumberControl.tsx
@@ -9,13 +9,11 @@ export type Props = {
   className?: string;
 };
 
-// Timer reference returned by setTimeout
-type TODO__TIMER = ReturnType<typeof setTimeout>;
 
 const DELAY_SCROLL_TIME_OUT_MS = 1000;
 
 export const PageNumberControl: React.FunctionComponent<Props> = ({ className }: Props) => {
-  const delayTimerRef = React.useRef<TODO__TIMER>();
+  const delayTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
   const { numPages } = React.useContext(DocumentContext);
   const { scrollToPage, visiblePageRatios } = React.useContext(ScrollContext);
   const [minPage, setMinPage] = React.useState<number>(0);

--- a/ui/library/src/components/PageWrapper.tsx
+++ b/ui/library/src/components/PageWrapper.tsx
@@ -44,14 +44,23 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
   const { pageDimensions, getOutlineTargets, setNumPagesLoaded } =
     React.useContext(DocumentContext);
   const { getObjectURLForPage, isBuildingObjectURLForPage } = React.useContext(PageRenderContext);
-  const { isLoading } = React.useContext(UiContext);
+  const { isLoading, errorMessage } = React.useContext(UiContext);
 
   const objectURLForPage = getObjectURLForPage({ pageIndex });
   const isBuildingPageImage = isBuildingObjectURLForPage({ pageIndex });
 
-  // Don't display until we have page size data
-  // TODO: Handle this nicer so we display either the loading or error treatment
-  if (!pageDimensions) {
+  // If we don't have valid page size data, show the loading or error states
+  if (!pageDimensions?.height || !pageDimensions?.width) {
+    if (isLoading && loading) {
+      return <>{typeof loading === 'function' ? loading() : loading}</>;
+    }
+    if (!isLoading && errorMessage && error) {
+      const err = new Error(errorMessage);
+      return <>{typeof error === 'function' ? error({ error: err }) : error}</>;
+    }
+    if (!isLoading && !errorMessage && noData) {
+      return <>{typeof noData === 'function' ? noData() : noData}</>;
+    }
     return null;
   }
 
@@ -80,7 +89,6 @@ export const PageWrapper: React.FunctionComponent<Props> = ({
 
   // Width needs to be set to prevent the outermost Page div from extending to fit the parent,
   // and mis-aligning the text layer.
-  // TODO: Can we CSS this to auto-shrink?
   return (
     <div
       id={generatePageIdFromIndex(pageIndex)}

--- a/ui/library/src/utils/scale.ts
+++ b/ui/library/src/utils/scale.ts
@@ -6,9 +6,15 @@ export interface IPDFPageProxy {
   view: Array<number>; // format: [ top left x coordinate, top left y coordinate, bottom right x, bottom right y]
 }
 
-// We assume 96 DPI for display
-// TODO: There are more accurate ways to do this, but this is what ScholarPhi does now
-const DPI = 96;
+// We assume 96 DPI for display, but adjust for the current device's pixel ratio
+const DEFAULT_DPI = 96;
+
+export function getDisplayDPI(): number {
+  if (typeof window !== 'undefined' && typeof window.devicePixelRatio === 'number') {
+    return DEFAULT_DPI * window.devicePixelRatio;
+  }
+  return DEFAULT_DPI;
+}
 
 // PDF units are in 1/72nds of an inch
 const USER_UNIT_DENOMINATOR = 72;
@@ -20,7 +26,8 @@ const USER_UNIT_DENOMINATOR = 72;
  */
 export function computePageDimensions(page: IPDFPageProxy): Dimensions {
   const [leftPx, topPx, rightPx, bottomPx] = page.view;
-  const PPI = (page.userUnit / USER_UNIT_DENOMINATOR) * DPI;
+  const dpi = getDisplayDPI();
+  const PPI = (page.userUnit / USER_UNIT_DENOMINATOR) * dpi;
 
   return {
     height: (bottomPx - topPx) * PPI,


### PR DESCRIPTION
## Summary
- remove unused timer alias in PageNumberControl
- show loader or error in PageWrapper until dimensions are known
- improve display DPI detection and clean TODO

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*